### PR TITLE
Fixed: sample rate problem, readme's code and source is too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ audio.fetchAudio('/song.mp3', '/another-song.mp3')
 		audio.download(output.blob);
 		document.append(output.element);
 		console.log(output.url);
-	});
+	})
 	.catch((error) => {
 		// => Error Message
 	});
@@ -44,7 +44,7 @@ let audio = new Crunker();
 audio.fetchAudio('/voice.mp3', '/shell.mp3')
 	.then(buffers => audio.mergeAudio(buffers))
 	.then(merged => audio.export(merged, 'audio/mp3'))
-	.then(output => audio.download(output.blob)})
+	.then(output => audio.download(output.blob))
 	.catch(error => throw new Error(error))
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ audio.fetchAudio('/voice.mp3', '/shell.mp3')
 	.then(buffers => audio.mergeAudio(buffers))
 	.then(merged => audio.export(merged, 'audio/mp3'))
 	.then(output => audio.download(output.blob))
-	.catch(error => throw new Error(error))
+	.catch(error => {throw new Error(error)})
 ```
 
 # Methods

--- a/src/crunker.js
+++ b/src/crunker.js
@@ -32,7 +32,7 @@ class Crunker {
 	}
 
 	concatAudio(buffers) {
-		let output = this._context.createBuffer(1, sampleRate*this._totalDuration(buffers), sampleRate),
+		let output = this._context.createBuffer(1, sampleRate*this._totalLength(buffers), sampleRate),
 			offset = 0;
 		buffers.map(buffer => {
 			output.getChannelData(0).set(buffer.getChannelData(0), offset);
@@ -85,8 +85,8 @@ class Crunker {
 		return Math.max.apply(Math, buffers.map(buffer => buffer.duration));
 	}
 
-	_totalDuration(buffers) {
-		return buffers.map(buffer => buffer.duration).reduce((a, b) => a + b, 0);
+	_totalLength(buffers) {
+		return buffers.map(buffer => buffer.length).reduce((a, b) => a + b, 0);
 	}
 
 	_isSupported() {

--- a/src/crunker.js
+++ b/src/crunker.js
@@ -1,5 +1,10 @@
 'use strict';
-const sampleRate = 48000; // Default: 44100
+
+/**
+ * See: https://github.com/jackedgson/crunker/issues/4
+ * This number should reflect the sample rate in Hz of the audio files.
+ */
+const sampleRate = 44100; // or 48000 (Hz) 
 
 class Crunker {
 

--- a/src/crunker.js
+++ b/src/crunker.js
@@ -1,4 +1,5 @@
 'use strict';
+const sampleRate = 48000; // Default: 44100
 
 class Crunker {
 
@@ -20,7 +21,7 @@ class Crunker {
 	}
 
 	mergeAudio(buffers) {
-		let output = this._context.createBuffer(1, 44100*this._maxDuration(buffers), 44100);
+		let output = this._context.createBuffer(1, sampleRate*this._maxDuration(buffers), sampleRate);
 
 		buffers.map(buffer => {
 			for (let i = buffer.getChannelData(0).length - 1; i >= 0; i--) {
@@ -31,7 +32,7 @@ class Crunker {
 	}
 
 	concatAudio(buffers) {
-		let output = this._context.createBuffer(1, 44100*this._totalDuration(buffers), 44100),
+		let output = this._context.createBuffer(1, sampleRate*this._totalDuration(buffers), sampleRate),
 			offset = 0;
 		buffers.map(buffer => {
 			output.getChannelData(0).set(buffer.getChannelData(0), offset);
@@ -103,8 +104,8 @@ class Crunker {
 		view.setUint32(16, 16, true);
 		view.setUint16(20, 1, true);
 		view.setUint16(22, 2, true);
-		view.setUint32(24, 44100, true);
-		view.setUint32(28, 44100 * 4, true);
+		view.setUint32(24, sampleRate, true);
+		view.setUint32(28, sampleRate * 4, true);
 		view.setUint16(32, 4, true);
 		view.setUint16(34, 16, true);
 		this._writeString(view, 36, 'data');


### PR DESCRIPTION
# Sample rate problem
This problem wasn't known, but when I tried to use this library I went through it. If you use a source that have a sample rate different of 44100, the new audio will have some distortion. To improve the library and have an more accessible way to change that sample rate, I created an constant to define the rate that I want to use. **But**, in the future, is wanted that the library detect the rate from the source provided. May be launch an error if sources with different sample rate was provided.

# README's code
Just little bugs: one `;` where it should not and one `{` missing.

# Source is too large
To fix the #4 issue, I changed the method of define the length on creating the buffer. It was defined by `44100 * _totalLength(buffers)`. But some times this results in a minor value of that is necessary whem ew call the `set()` method of the `Float32Array` passing the last offset. The new way is just passing the total length of the samples, by the new func `_totalLength`