### PR TITLE
fix: check equipment sampleRate

### DIFF
--- a/src/crunker.js
+++ b/src/crunker.js
@@ -2,8 +2,12 @@
 
 export default class Crunker {
   constructor({ sampleRate = 44100 } = {}) {
-    this._sampleRate = sampleRate;
     this._context = this._createContext();
+    this._sampleRate = sampleRate;
+
+    if (this._context.sampleRate > sampleRate) {
+      this._sampleRate = this._context.sampleRate;
+    }
   }
 
   _createContext() {


### PR DESCRIPTION
iPhone and other morden equipments will use higher sampleRate: 48000 , if still use the default sampleRate to concat the audio file '.wav' or '.mp3', the sounds of the merged file isn't as same as the origin file.

I have tested on windows pc ,iMac, some android and iPhone devices, only iMac can use the default 44100 sample rate to concat file with origin sounds

this._context.sampleRate echo 48000 in other devices.