### PR TITLE
Use standardized-audio-context and update webpack-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
+  },
+  "dependencies": {
+    "standardized-audio-context": "^25.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai": "^3.5.0",
     "mocha": "^3.3.0",
     "webpack": "^4.17.0",
-    "webpack-cli": "^2.0.13"
+    "webpack-cli": "^4.1.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/src/crunker.js
+++ b/src/crunker.js
@@ -1,4 +1,5 @@
 "use strict";
+const { AudioContext } = require("standardized-audio-context");
 
 export default class Crunker {
   constructor({ sampleRate = 44100 } = {}) {
@@ -7,10 +8,12 @@ export default class Crunker {
   }
 
   _createContext() {
+    /*
     window.AudioContext =
       window.AudioContext ||
       window.webkitAudioContext ||
       window.mozAudioContext;
+    */
     return new AudioContext();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -350,6 +357,14 @@ asynckit@^0.4.0:
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+
+automation-events@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/automation-events/-/automation-events-3.0.2.tgz#157726fd899d82665667a8b07d61dd8297768413"
+  integrity sha512-dlhjhSK/EF2aNjBtR/s41rbKsDSCT1sRreO8g6D39+bgY/rk+mmLX3Bhned4Q3ljT79T4T+ydsSOXT5zIt1aqw==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tslib "^2.0.3"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -4557,6 +4572,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
@@ -5018,6 +5038,15 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
+standardized-audio-context@^25.1.4:
+  version "25.1.4"
+  resolved "https://registry.yarnpkg.com/standardized-audio-context/-/standardized-audio-context-25.1.4.tgz#88dcca96d9ac645c7897ba10f544c01fe5272cdd"
+  integrity sha512-KsF1sMPlf6ODBVEzpILWUkYO4erl+MN5KM5RTg6bM0WbSgKT5xgd1zwx6saHg1jT4gpR63ApWki/Xqm3QNviBg==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    automation-events "^3.0.2"
+    tslib "^2.0.3"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -5291,6 +5320,11 @@ trim-right@^1.0.1:
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tslib@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Thanks for the repo. It works great on Chrome but I was getting errors on Safari on my computer and iPhone. I was getting  `TypeError: Not enough arguments` caused by `this._context.decodeAudioData(buffer)` in line 22 of crunker.js:

According to [this](https://stackoverflow.com/questions/52489787/audiocontext-decodeaudiodata-not-working-on-iphone-but-working-everywhere-e) StackOverflow answer, it is caused by `decodeAudioData()` using callbacks instead of promises in Safari.

This [package](standardized-audio-context) handles all the nuances of Web Audio API for different browsers while providing a standardized interface so I altered the code to use it. I got some errors while trying to install the package, which got fixed by upgrading `webpack-cli@2.0.13` -> `webpack-cli@4.1.0`. Now everything seems to be working on Safari.