### PR TITLE
Implemented files for fetchAudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ crunker
   });
 ```
 
+# Input file Example
+
+```javascript
+let crunker = new Crunker();
+
+const onFileInputChange = async (target) => {
+  const buffers = await crunker.fetchAudio(...target.files, "/voice.mp3", "/background.mp3");
+};
+
+<input
+  onChange={onFileInputChange(this)}
+  type="file"
+  accept="audio/*"
+/>
+```
+
 # [Graphic Representation of Methods](https://github.com/jackedgson/crunker/issues/16)
 
 ## Merge

--- a/src/crunker.js
+++ b/src/crunker.js
@@ -16,9 +16,14 @@ export default class Crunker {
 
   async fetchAudio(...filepaths) {
     const files = filepaths.map(async (filepath) => {
-      const buffer = await fetch(filepath).then((response) =>
-        response.arrayBuffer()
-      );
+      let buffer;
+
+      if (filepath instanceof File) {
+        buffer = await filepath.arrayBuffer();
+      } else {
+        buffer = await fetch(filepath).then((response) => response.arrayBuffer());
+      }
+
       return await this._context.decodeAudioData(buffer);
     });
     return await Promise.all(files);


### PR DESCRIPTION
Now you can send Files to Crunker (or combine it with file paths).
Code in example is bad practice because it uses 'private' method `decodeAudioData`.
https://github.com/jackedgson/crunker/blob/9b8afbb1db87c540b099c13d56c78adf95326c72/examples/client/index.html#L45 