### PR TITLE
fix: update incorrect MIME type default

### DIFF
--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -173,10 +173,14 @@ export default class Crunker {
   /**
    * Exports the specified AudioBuffer to a Blob, Object URI and HTMLAudioElement.
    *
+   * Note that changing the MIME type does not change the actual file format. The
+   * file format will **always** be a WAVE file due to how audio is stored in the
+   * browser.
+   *
    * @param buffer Buffer to export
-   * @param type MIME type (default: `audio/mp3`)
+   * @param type MIME type (default: `audio/wav`)
    */
-  export(buffer: AudioBuffer, type: string = 'audio/mp3'): ExportedCrunkerAudio {
+  export(buffer: AudioBuffer, type: string = 'audio/wav'): ExportedCrunkerAudio {
     const recorded = this._interleave(buffer);
     const dataview = this._writeHeaders(recorded);
     const audioBlob = new Blob([dataview], { type });


### PR DESCRIPTION
Audio is always stored in the browser as WAVE PCM audio.

When we export the blob, despite providing an mp3 MIME type, the resulting Blob is still actually a WAVE PCM file. The MIME type provided is just to help the browser make sense of the Blob and does not determine the data exported.

If you open a downloaded Crunker audio file, the magic bytes (`52 49 46 46`) point to the exported file being a `.wav` file. Most software fix this silently in the background for you, so it's unlikely that it would even be noticed.