### PR TITLE
feat: auto-detect device sample rate if not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ const onFileInputChange = async (target) => {
 
 For more detailed API documentation, view the Typescript typings.
 
-## new Crunker({ sampleRate: 44100 })
+## new Crunker()
 
-Create a new Crunker.
-You may optionally provide an object with a `sampleRate` key, defaults to 44100.
+Create a new instance of Crunker.
+You may optionally provide an object with a `sampleRate` key, but it will default to the same sample rate as the internal audio context, which is appropriate for your device.
 
 ## crunker.fetchAudio(songURL, anotherSongURL)
 

--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -27,10 +27,16 @@ export default class Crunker {
 
   /**
    * Creates a new instance of Crunker with the provided options.
+   *
+   * If `sampleRate` is not defined, it will auto-select an appropriate sample rate
+   * for the device being used.
    */
-  constructor({ sampleRate = 44100 }: Partial<CrunkerConstructorOptions> = {}) {
-    this._sampleRate = sampleRate;
+  constructor({ sampleRate }: Partial<CrunkerConstructorOptions> = {}) {
     this._context = this._createContext();
+
+    sampleRate ||= this._context.sampleRate;
+
+    this._sampleRate = sampleRate;
   }
 
   /**


### PR DESCRIPTION
This PR changes Crunker to default to a sample rate appropriate to the device when one is not provided during instantiation.

This is as discussed in https://github.com/jackedgson/crunker/issues/36#issuecomment-1075869342.