### PR TITLE
fix: Links to examples in Readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple way to merge, concatenate, play, export and download audio files with the
 - Tiny 2kB gzipped
 - Written in Typescript
 
-[View online demos](https://jackedgson.github.io/crunker/examples/)
+[View online demos](https://jaggad.github.io/crunker/examples/)
 
 # Installation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,5 +4,6 @@ This directory contains some examples of possible use-cases for crunker.js and t
 
 ## Live Demos
 
-- [Audio from Client](https://jackedgson.github.io/crunker/examples/client/index.html)
-- [Audio from Server](https://jackedgson.github.io/crunker/examples/server/index.html)
+- [Audio from Client](https://jaggad.github.io/crunker/examples/client/index.html)
+- [Audio from Server](https://jaggad.github.io/crunker/examples/server/index.html)
+- [Beat Builder](https://jaggad.github.io/crunker/examples/client/beatBuilder.html)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jackedgson/crunker.git"
+    "url": "git+https://github.com/jaggad/crunker.git"
   },
   "keywords": [
     "web-audio-api",
@@ -36,9 +36,9 @@
   "author": "Jack Edgson",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jackedgson/crunker/issues"
+    "url": "https://github.com/jaggad/crunker/issues"
   },
-  "homepage": "https://github.com/jackedgson/crunker#readme",
+  "homepage": "https://github.com/jaggad/crunker#readme",
   "devDependencies": {
     "@babel/cli": "^7.16.8",
     "@babel/core": "^7.16.12",


### PR DESCRIPTION
Some of them were broken and lead to 404 page:
<img width="547" alt="image" src="https://user-images.githubusercontent.com/41756225/185927394-fa1cd14d-f4f4-4475-83c8-9aae27ed6b46.png">

Also adds a link to new beatBuilder example.


Having started with easy things, I'd love to commit more in the near future