### PR TITLE
publish only required files to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
   ],
   "author": "Jack Edgson",
   "license": "MIT",
+  "files": [
+    "LICENSE"
+    "README.md",
+    "dist",
+  ],
   "bugs": {
     "url": "https://github.com/jaggad/crunker/issues"
   },


### PR DESCRIPTION
Currently, library published with all files which were in folder of the machine from which publishing was done. 

It includes `.yarn` with whole yarn cache and yarn distributable, examples and so on. This is dramatically increase installation size of the package. 

This PR adds `files` field to `package.json` which is whitelist only necessary files and folders. 

Feel free to add to this field if i forgot something. 