### PR TITLE
fix: pitch/speed issue on devices with different sample rates

### DIFF
--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -46,7 +46,7 @@ export default class Crunker {
    */
   private _createContext(sampleRate: number = 44_100): AudioContext {
     window.AudioContext = window.AudioContext || (window as any).webkitAudioContext || (window as any).mozAudioContext;
-    return new AudioContext({sampleRate});
+    return new AudioContext({ sampleRate });
   }
 
   /**

--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -32,7 +32,7 @@ export default class Crunker {
    * for the device being used.
    */
   constructor({ sampleRate }: Partial<CrunkerConstructorOptions> = {}) {
-    this._context = this._createContext();
+    this._context = this._createContext(sampleRate);
 
     sampleRate ||= this._context.sampleRate;
 
@@ -44,9 +44,9 @@ export default class Crunker {
    *
    * @internal
    */
-  private _createContext(): AudioContext {
+  private _createContext(sampleRate: number = 44_100): AudioContext {
     window.AudioContext = window.AudioContext || (window as any).webkitAudioContext || (window as any).mozAudioContext;
-    return new AudioContext();
+    return new AudioContext({sampleRate});
   }
 
   /**


### PR DESCRIPTION
This fixes an issue where different devices and browsers would result in pitch/speed discrepancies when playing back audio files.

The `sampleRate` option wasn't well supported, but is now implemented by all browsers: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext#browser_compatibility

Fixes #23, #15 