### PR TITLE
Improve audio interleaving

### DIFF
--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -394,8 +394,15 @@ export default class Crunker {
    * @internal
    */
   private _interleave(input: AudioBuffer): Float32Array {
-    const channels = Array.from({ length: input.numberOfChannels }, (_, i) => i);
-    const length = channels.reduce((prev, channelIdx) => prev + input.getChannelData(channelIdx).length, 0);
+    if (input.numberOfChannels === 1) {
+        // No need to interleave channels, just return single channel data to save performance and memory
+        return input.getChannelData(0);
+    }
+    const channels = [];
+    for (let i = 0; i < input.numberOfChannels; i++) {
+        channels.push(input.getChannelData(i));
+    }
+    const length = channels.reduce((prev, channelData) => prev + channelData.length, 0);
     const result = new Float32Array(length);
 
     let index = 0;
@@ -403,11 +410,11 @@ export default class Crunker {
 
     // for 2 channels its like: [L[0], R[0], L[1], R[1], ... , L[n], R[n]]
     while (index < length) {
-      channels.forEach((channelIdx) => {
-        result[index++] = input.getChannelData(channelIdx)[inputIndex];
-      });
+        channels.forEach((channelData) => {
+            result[index++] = channelData[inputIndex];
+        });
 
-      inputIndex++;
+        inputIndex++;
     }
 
     return result;

--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -395,12 +395,12 @@ export default class Crunker {
    */
   private _interleave(input: AudioBuffer): Float32Array {
     if (input.numberOfChannels === 1) {
-        // No need to interleave channels, just return single channel data to save performance and memory
-        return input.getChannelData(0);
+      // No need to interleave channels, just return single channel data to save performance and memory
+      return input.getChannelData(0);
     }
     const channels = [];
     for (let i = 0; i < input.numberOfChannels; i++) {
-        channels.push(input.getChannelData(i));
+      channels.push(input.getChannelData(i));
     }
     const length = channels.reduce((prev, channelData) => prev + channelData.length, 0);
     const result = new Float32Array(length);
@@ -410,11 +410,11 @@ export default class Crunker {
 
     // for 2 channels its like: [L[0], R[0], L[1], R[1], ... , L[n], R[n]]
     while (index < length) {
-        channels.forEach((channelData) => {
-            result[index++] = channelData[inputIndex];
-        });
+      channels.forEach((channelData) => {
+        result[index++] = channelData[inputIndex];
+      });
 
-        inputIndex++;
+      inputIndex++;
     }
 
     return result;


### PR DESCRIPTION
I found a pretty difficult-to-reproduce scenario where the interleaving code would get 'stuck' following line https://github.com/jaggad/crunker/blob/0ac03d4edd28bf5e014efb6f1928ced9f088f483/src/crunker.ts#L407 where we're repeatedly calling `input.getChannelData()` potentially for millions of data in each audio channel.

I made the change to make this call only N times where N = number of channels and store the channel data in an array instead.

This PR also includes an early return in the interleaving code for scenarios where there's a single channel buffer which saves some memory and improves performance.