### PR TITLE
fix: batch network requests in `fetchAudio`

### DIFF
--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -58,9 +58,25 @@ export default class Crunker {
   }
 
   /**
-   * Asynchronously fetches multiple audio files and returns an array of AudioBuffers.
+   * Asynchronously fetches multiple audio files and returns an array of AudioBuffers,
+   * splitting into groups of 200 files to avoid resource exhaustion.
    */
   async fetchAudio(...filepaths: CrunkerInputTypes[]): Promise<AudioBuffer[]> {
+    const buffers: AudioBuffer[] = [];
+    const groups = Math.ceil(filepaths.length / 200);
+
+    for (let i = 0; i < groups; i++) {
+      const group = filepaths.slice(i * 200, (i + 1) * 200);
+      buffers.push(...(await this._fetchAudio(...group)));
+    }
+
+    return buffers;
+  }
+
+  /**
+   * Asynchronously fetches multiple audio files and returns an array of AudioBuffers.
+   */
+  private async _fetchAudio(...filepaths: CrunkerInputTypes[]): Promise<AudioBuffer[]> {
     return await Promise.all(
       filepaths.map(async (filepath) => {
         let buffer: ArrayBuffer;

--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -40,7 +40,7 @@ export default class Crunker {
    * If `sampleRate` is not defined, it will auto-select an appropriate sample rate
    * for the device being used.
    */
-  constructor({ sampleRate, concurrentNetworkRequests }: Partial<CrunkerConstructorOptions> = {}) {
+  constructor({ sampleRate, concurrentNetworkRequests = 200 }: Partial<CrunkerConstructorOptions> = {}) {
     this._context = this._createContext(sampleRate);
 
     sampleRate ||= this._context.sampleRate;

--- a/src/crunker.ts
+++ b/src/crunker.ts
@@ -5,6 +5,14 @@ export interface CrunkerConstructorOptions {
    * @default 44100
    */
   sampleRate: number;
+  /**
+   * Maximum number of concurrent network requests to use while fetching audio. Requests will be batched into groups of this size.
+   *
+   * Anything much higher than the default can cause issues in web browsers. You may wish to lower it for low-performance devices.
+   *
+   * @default 200
+   */
+  concurrentNetworkRequests: number;
 }
 
 export type CrunkerInputTypes = string | File | Blob;
@@ -23,6 +31,7 @@ export interface ExportedCrunkerAudio {
  */
 export default class Crunker {
   private readonly _sampleRate: number;
+  private readonly _concurrentNetworkRequests: number;
   private readonly _context: AudioContext;
 
   /**
@@ -31,12 +40,13 @@ export default class Crunker {
    * If `sampleRate` is not defined, it will auto-select an appropriate sample rate
    * for the device being used.
    */
-  constructor({ sampleRate }: Partial<CrunkerConstructorOptions> = {}) {
+  constructor({ sampleRate, concurrentNetworkRequests }: Partial<CrunkerConstructorOptions> = {}) {
     this._context = this._createContext(sampleRate);
 
     sampleRate ||= this._context.sampleRate;
 
     this._sampleRate = sampleRate;
+    this._concurrentNetworkRequests = concurrentNetworkRequests;
   }
 
   /**
@@ -58,15 +68,16 @@ export default class Crunker {
   }
 
   /**
-   * Asynchronously fetches multiple audio files and returns an array of AudioBuffers,
-   * splitting into groups of 200 files to avoid resource exhaustion.
+   * Asynchronously fetches multiple audio files and returns an array of AudioBuffers.
+   *
+   * Network requests are batched, and the size of these batches can be configured with the `concurrentNetworkRequests` option in the Crunker constructor.
    */
   async fetchAudio(...filepaths: CrunkerInputTypes[]): Promise<AudioBuffer[]> {
     const buffers: AudioBuffer[] = [];
-    const groups = Math.ceil(filepaths.length / 200);
+    const groups = Math.ceil(filepaths.length / this._concurrentNetworkRequests);
 
     for (let i = 0; i < groups; i++) {
-      const group = filepaths.slice(i * 200, (i + 1) * 200);
+      const group = filepaths.slice(i * this._concurrentNetworkRequests, (i + 1) * this._concurrentNetworkRequests);
       buffers.push(...(await this._fetchAudio(...group)));
     }
 


### PR DESCRIPTION
I decided to set my device on fire by asking Crunker to concatenate about 2800 mp3 files into one wav.

Crunker was fine to do this, but Chrome refused and failed some of the network requests, rather understandably.

To work around `ERR::INSUFFICIENT_RESOURCES`, I have implemented a batching mechanism into `fetchAudio` so Crunker will only attempt to fetch 200 files at any one time. This worked fine in my browser on the same set of 2800 files.

(For anyone wondering, the resulting WAV file was about 256 MB.)